### PR TITLE
Update to new Discord Game SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
     api 'net.java.dev.jna:jna:4.4.0'
-    implementation 'club.minnced:discord-rpc-release:v3.4.0'
+    implementation 'com.discord:discord-game-sdk:3.0.0'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     examplesCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.21'
     examplesCompile compileJava.classpath

--- a/examples/java/ml/yuuki/chris/rpc/examples/WindowTest.java
+++ b/examples/java/ml/yuuki/chris/rpc/examples/WindowTest.java
@@ -16,9 +16,11 @@
 
 package ml.yuuki.chris.rpc.examples;
 
-import com.discord.GameSDK.*;
-import com.discord.GameSDK.DiscordActivityManager.*;
-import com.discord.GameSDK.DiscordUserManager.*;
+import com.discord.GameSDK.DiscordActivity;
+import com.discord.GameSDK.DiscordActivityManager;
+import com.discord.GameSDK.DiscordCore;
+import com.discord.GameSDK.DiscordCreateFlags;
+import com.discord.GameSDK.DiscordResult;
 
 import javax.swing.*;
 import java.awt.*;


### PR DESCRIPTION
Update the examples, README, and build.gradle file to use the new Discord Game SDK.

* **build.gradle**
  - Update the `implementation` dependency to use the new Discord Game SDK.
  - Remove the old `discord-rpc-release` dependency.

* **examples/java/ml/yuuki/chris/rpc/examples/WindowTest.java**
  - Update the import statements to use the new Discord Game SDK.

* **README.md**
  - Update references to the new Discord Game SDK.
  - Update setup instructions to use the new Discord Game SDK.
  - Update example code to use the new Discord Game SDK.

