### PR TITLE
Fix Gradle dependency resolution issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ sourceCompatibility = targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     jcenter()
+    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2' }
 }
 
 dependencies {


### PR DESCRIPTION
Add Maven Central repository to `build.gradle` to resolve artifact issue.

* Add `mavenCentral()` to the `repositories` block.
* Add `maven { url 'https://repo.maven.apache.org/maven2' }` to the `repositories` block.

