### PR TITLE
Update README example to use java-discord-rpc package

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ dependencies {
 The library can be used just like the SDK. This means you can almost copy the exact code used in the official documentation.
 
 ```java
-import com.discord.GameSDK.*;
+import cavespider.discord.rpc.DiscordGameSDK.*;
 
 public class Main {
     public static void main(String[] args) {


### PR DESCRIPTION
Update the README to include an example on how to use this package (java-discord-rpc)

* Modify the import statement in the example to import classes from `cavespider.discord.rpc` package instead of `com.discord.GameSDK`.
* Adjust the example code to use `DiscordGameSDK` methods and classes.

